### PR TITLE
Use dedicated config directory instead of app folder

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -20,7 +20,7 @@ Pull the repo with recursive submodule initialization and then run `./build.ps1`
 
 ## Where is config file?
 
-At first start app will create new config file (default location is [`/ext/apps/Misc/totp.conf`](https://github.com/akopachov/flipper-zero_authenticator/blob/master/totp/services/config/config.c#:~:text=%23define%20CONFIG_FILE_DIRECTORY_PATH,totp.conf%22)).
+At first start app will create new config file (default location is [`/ext/authenticator/totp.conf`](https://github.com/akopachov/flipper-zero_authenticator/blob/master/totp/services/config/config.c#:~:text=%23define%20CONFIG_FILE_DIRECTORY_PATH,totp.conf%22)).
 
 Detailed description of file format can be found [here](docs/conf-file_description.md)
 

--- a/docs/conf-file_description.md
+++ b/docs/conf-file_description.md
@@ -1,6 +1,6 @@
 # Flipper Authenticator config file description
 
-By default Flipper Authenticator stores all its settings in [`/ext/apps/Misc/totp.conf`](https://github.com/akopachov/flipper-zero_authenticator/blob/master/totp/services/config/config.c#:~:text=%23define%20CONFIG_FILE_DIRECTORY_PATH,totp.conf%22) file.
+By default Flipper Authenticator stores all its settings in [`/ext/authenticator/totp.conf`](https://github.com/akopachov/flipper-zero_authenticator/blob/master/totp/services/config/config.c#:~:text=%23define%20CONFIG_FILE_DIRECTORY_PATH,totp.conf%22) file.
 
 File format is standard for Flipper Zero device. Each line has one setting identified by key, where key and value are separated by `:` symbol.
 

--- a/totp/services/config/config.c
+++ b/totp/services/config/config.c
@@ -9,6 +9,7 @@
 #define CONFIG_FILE_DIRECTORY_PATH EXT_PATH("authenticator")
 #define CONFIG_FILE_PATH CONFIG_FILE_DIRECTORY_PATH "/totp.conf"
 #define CONFIG_FILE_BACKUP_PATH CONFIG_FILE_PATH ".backup"
+#define CONFIG_FILE_PATH_PREVIOUS EXT_PATH("apps/Misc") "/totp.conf"
 
 static char* token_info_get_algo_as_cstr(const TokenInfo* token_info) {
     switch(token_info->algo) {
@@ -53,6 +54,22 @@ FlipperFormat* totp_open_config_file(Storage* storage) {
             totp_close_config_file(fff_data_file);
             return NULL;
         }
+    } else if(storage_common_stat(storage, CONFIG_FILE_PATH_PREVIOUS, NULL) == FSE_OK) {
+        FURI_LOG_D(LOGGING_TAG, "Old config file %s found", CONFIG_FILE_PATH_PREVIOUS);
+        if(storage_common_stat(storage, CONFIG_FILE_DIRECTORY_PATH, NULL) == FSE_NOT_EXIST) {
+            FURI_LOG_D(
+                LOGGING_TAG,
+                "Directory %s doesn't exist. Will create new.",
+                CONFIG_FILE_DIRECTORY_PATH);
+            if(!storage_simply_mkdir(storage, CONFIG_FILE_DIRECTORY_PATH)) {
+                FURI_LOG_E(LOGGING_TAG, "Error creating directory %s", CONFIG_FILE_DIRECTORY_PATH);
+                return NULL;
+            }
+        }
+        storage_common_copy(storage, CONFIG_FILE_PATH_PREVIOUS, CONFIG_FILE_PATH);
+        storage_simply_remove(storage, CONFIG_FILE_PATH_PREVIOUS);
+        FURI_LOG_I(LOGGING_TAG, "Applied config file path migration");
+        return totp_open_config_file(storage);
     } else {
         FURI_LOG_D(LOGGING_TAG, "Config file %s is not found. Will create new.", CONFIG_FILE_PATH);
         if(storage_common_stat(storage, CONFIG_FILE_DIRECTORY_PATH, NULL) == FSE_NOT_EXIST) {

--- a/totp/services/config/config.c
+++ b/totp/services/config/config.c
@@ -66,8 +66,10 @@ FlipperFormat* totp_open_config_file(Storage* storage) {
                 return NULL;
             }
         }
-        storage_common_copy(storage, CONFIG_FILE_PATH_PREVIOUS, CONFIG_FILE_PATH);
-        storage_simply_remove(storage, CONFIG_FILE_PATH_PREVIOUS);
+        if(storage_common_rename(storage, CONFIG_FILE_PATH_PREVIOUS, CONFIG_FILE_PATH) != FSE_OK) {
+            FURI_LOG_E(LOGGING_TAG, "Error moving config to %s", CONFIG_FILE_PATH);
+            return NULL;
+        }
         FURI_LOG_I(LOGGING_TAG, "Applied config file path migration");
         return totp_open_config_file(storage);
     } else {

--- a/totp/services/config/config.c
+++ b/totp/services/config/config.c
@@ -6,7 +6,7 @@
 #include "../../types/token_info.h"
 #include "migrations/config_migration_v1_to_v2.h"
 
-#define CONFIG_FILE_DIRECTORY_PATH "/ext/apps/Misc"
+#define CONFIG_FILE_DIRECTORY_PATH EXT_PATH("authenticator")
 #define CONFIG_FILE_PATH CONFIG_FILE_DIRECTORY_PATH "/totp.conf"
 #define CONFIG_FILE_BACKUP_PATH CONFIG_FILE_PATH ".backup"
 


### PR DESCRIPTION
Like for the U2F app, changed to dedicated configuration direcotry (`/ext/authenticator/`) to store config file.
Added file migration if config is in old path (`/ext/app/Misc/`).