### PR TITLE
Fix BT adv name length on Xtreme firmware

### DIFF
--- a/totp/workers/bt_type_code/bt_type_code.h
+++ b/totp/workers/bt_type_code/bt_type_code.h
@@ -7,7 +7,7 @@
 #include "../../features_config.h"
 
 #if TOTP_TARGET_FIRMWARE == TOTP_FIRMWARE_XTREME
-#define TOTP_BT_WORKER_BT_ADV_NAME_MAX_LEN (18)
+#define TOTP_BT_WORKER_BT_ADV_NAME_MAX_LEN FURI_HAL_BT_ADV_NAME_LENGTH
 #define TOTP_BT_WORKER_BT_MAC_ADDRESS_LEN GAP_MAC_ADDR_SIZE
 #endif
 
@@ -24,7 +24,7 @@ typedef struct {
     bool is_connected;
 #if TOTP_TARGET_FIRMWARE == TOTP_FIRMWARE_XTREME
     uint8_t bt_mac[TOTP_BT_WORKER_BT_MAC_ADDRESS_LEN];
-    char previous_bt_name[TOTP_BT_WORKER_BT_ADV_NAME_MAX_LEN + 1];
+    char previous_bt_name[TOTP_BT_WORKER_BT_ADV_NAME_MAX_LEN];
     uint8_t previous_bt_mac[TOTP_BT_WORKER_BT_MAC_ADDRESS_LEN];
 #endif
 } TotpBtTypeCodeWorkerContext;


### PR DESCRIPTION
I pinged you on the Xtreme discord about this, I'll recap the issue: BT name was limited to size 18, aka 17 chars + 1 null terminator. This was fine as it was designed for `"Control {flipper name}"`, which can be at most 17 characters (8 for flipper name + 9 for "Control "). In this case however `"{flipper name} TOTP Auth"` could end up being 18 chars (8 flipper name + 10 for " TOTP Auth") and it would get cutoff as `"{flipper name} TOTP Aut"`. I tried expanding this but BLE didn't like it that much, I only managed to get 1 more character out of it. But I also implemented it properly with https://github.com/ClaraCrazy/Flipper-Xtreme/commit/8aed004b7b274ff35fd19c7794c8ae8caeea7828 so you can use `FURI_HAL_BT_ADV_NAME_LENGTH` to base your strings off that you will pass to `furi_hal_bt_set_profile_adv_name()`.

TL;DR: Fixed cutoff BT name when flipper name is 8 characters long, also made it cleaner by using a firmware macro for max name length